### PR TITLE
fix: :passport_control: remove web navigation permission

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -11,7 +11,6 @@ const manifest: chrome.runtime.Manifest = {
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png",
   },
-  permissions: ["webNavigation"],
   content_scripts: [
     {
       run_at: "document_idle",


### PR DESCRIPTION
The extension has been rejected by Google since it request for permission of web navigation, but not using it.