### PR TITLE
ci: :green_heart: trigger update `bun.lockb` workflow by branch name

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,8 +2,8 @@ name: "Dependabot: Update bun.lockb 🤖"
 
 on:
   pull_request:
-    paths:
-      - "package.json"
+    branches:
+      - "dependabot/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
Using head branch name to trigger workflow instead of file path.